### PR TITLE
Add delete support to es233

### DIFF
--- a/heroic-component/src/main/java/com/spotify/heroic/metric/QueryError.java
+++ b/heroic-component/src/main/java/com/spotify/heroic/metric/QueryError.java
@@ -30,4 +30,8 @@ public class QueryError implements RequestError {
     public static RequestError fromMessage(final String message) {
         return new QueryError(message);
     }
+
+    public static QueryError fromThrowable(final Throwable e) {
+        return new QueryError(e.getMessage());
+    }
 }

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/Connection.java
@@ -35,6 +35,7 @@ import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateResponse;
 import org.elasticsearch.action.count.CountRequestBuilder;
+import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
@@ -132,5 +133,10 @@ public class Connection {
 
     public SearchScrollRequestBuilder prepareSearchScroll(String scrollId) {
         return client.getClient().prepareSearchScroll(scrollId);
+    }
+
+    public List<DeleteRequestBuilder> delete(DateRange range, String type, String id)
+        throws NoIndexSelectedException {
+        return index.delete(client.getClient(), range, type, id);
     }
 }

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/IndexMapping.java
@@ -25,8 +25,11 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.spotify.heroic.common.DateRange;
 import org.elasticsearch.action.count.CountRequestBuilder;
+import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.client.Client;
+
+import java.util.List;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
@@ -44,5 +47,16 @@ public interface IndexMapping {
         throws NoIndexSelectedException;
 
     CountRequestBuilder count(Client client, DateRange range, String type)
+        throws NoIndexSelectedException;
+
+    /**
+     * Create a delete request using the given client.
+     *
+     * @param client Client to create request with
+     * @param type Type of document to delete
+     * @param id Id of document to delete
+     * @return a new delete request
+     */
+    List<DeleteRequestBuilder> delete(Client client, DateRange range, String type, String id)
         throws NoIndexSelectedException;
 }

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMapping.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/RotatingIndexMapping.java
@@ -28,6 +28,7 @@ import com.spotify.heroic.common.DateRange;
 import com.spotify.heroic.common.Duration;
 import lombok.ToString;
 import org.elasticsearch.action.count.CountRequestBuilder;
+import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
@@ -142,6 +143,19 @@ public class RotatingIndexMapping implements IndexMapping {
     public CountRequestBuilder count(final Client client, final DateRange range, final String type)
         throws NoIndexSelectedException {
         return client.prepareCount(readIndices(range)).setIndicesOptions(options()).setTypes(type);
+    }
+
+    @Override
+    public List<DeleteRequestBuilder> delete(
+        final Client client, final DateRange range, final String type, final String id
+    ) throws NoIndexSelectedException {
+        final List<DeleteRequestBuilder> requests = new ArrayList<>();
+
+        for (final String index : readIndices(range)) {
+            requests.add(client.prepareDelete(index, type, id));
+        }
+
+        return requests;
     }
 
     private IndicesOptions options() {

--- a/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/SingleIndexMapping.java
+++ b/heroic-elasticsearch-utils/src/main/java/com/spotify/heroic/elasticsearch/index/SingleIndexMapping.java
@@ -23,12 +23,15 @@ package com.spotify.heroic.elasticsearch.index;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import com.spotify.heroic.common.DateRange;
 import lombok.ToString;
 import org.elasticsearch.action.count.CountRequestBuilder;
+import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.client.Client;
 
+import java.util.List;
 import java.util.Optional;
 
 @ToString
@@ -75,6 +78,13 @@ public class SingleIndexMapping implements IndexMapping {
         final Client client, final DateRange range, final String type
     ) {
         return client.prepareCount(index).setTypes(type);
+    }
+
+    @Override
+    public List<DeleteRequestBuilder> delete(
+        final Client client, final DateRange range, final String type, final String id
+    ) throws NoIndexSelectedException {
+        return ImmutableList.of(client.prepareDelete(index, type, id));
     }
 
     public static Builder builder() {

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -239,8 +239,8 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
         return doto(c -> {
             final OptionalLimit limit = filter.getLimit();
             final QueryBuilder f = filter(filter.getFilter());
-                    return entries(filter.getFilter(), filter.getLimit(), filter.getRange(), this::toSeries,
-            l -> FindSeries.of(l.getSet(), l.isLimited()), builder -> {
+            return entries(filter.getFilter(), filter.getLimit(), filter.getRange(), this::toSeries,
+                l -> FindSeries.of(l.getSet(), l.isLimited()), builder -> {
                 });
         });
     }

--- a/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
+++ b/metadata/elasticsearch/src/main/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendKV.java
@@ -57,15 +57,20 @@ import com.spotify.heroic.metadata.FindSeriesStream;
 import com.spotify.heroic.metadata.FindTags;
 import com.spotify.heroic.metadata.MetadataBackend;
 import com.spotify.heroic.metadata.WriteMetadata;
+import com.spotify.heroic.metric.QueryError;
+import com.spotify.heroic.metric.RequestError;
 import com.spotify.heroic.statistics.MetadataBackendReporter;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.Managed;
 import eu.toolchain.async.ManagedAction;
+import eu.toolchain.async.StreamCollector;
 import eu.toolchain.async.Transform;
 import lombok.ToString;
 import org.apache.commons.lang3.tuple.Pair;
+import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.count.CountRequestBuilder;
+import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.index.IndexRequest.OpType;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -91,9 +96,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.query.QueryBuilders.andQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
@@ -124,12 +132,13 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
     private final Managed<Connection> connection;
     private final RateLimitedCache<Pair<String, HashCode>> writeCache;
     private final boolean configure;
+    private final int deleteParallelism;
 
     @Inject
     public MetadataBackendKV(
         Groups groups, MetadataBackendReporter reporter, AsyncFramework async,
         Managed<Connection> connection, RateLimitedCache<Pair<String, HashCode>> writeCache,
-        @Named("configure") boolean configure
+        @Named("configure") boolean configure, @Named("deleteParallelism") int deleteParallelism
     ) {
         super(async, TYPE_METADATA);
         this.groups = groups;
@@ -138,6 +147,7 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
         this.connection = connection;
         this.writeCache = writeCache;
         this.configure = configure;
+        this.deleteParallelism = deleteParallelism;
     }
 
     @Override
@@ -272,7 +282,29 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
     @Override
     public AsyncFuture<DeleteSeries> deleteSeries(final DeleteSeries.Request request) {
-        return async.failed(new RuntimeException("Not implemented"));
+        final DateRange range = request.getRange();
+
+        final FindSeriesIds.Request findIds =
+            new FindSeriesIds.Request(request.getFilter(), range, request.getLimit());
+
+        return doto(c -> findSeriesIds(findIds).lazyTransform(ids -> {
+            final List<Callable<AsyncFuture<Void>>> deletes = new ArrayList<>();
+
+            for (final String id : ids.getIds()) {
+                deletes.add(() -> {
+                    final List<DeleteRequestBuilder> requests =
+                        c.delete(range, TYPE_METADATA, id);
+
+                    return async.collectAndDiscard(requests
+                        .stream()
+                        .map(ActionRequestBuilder::execute)
+                        .map(this::bind)
+                        .collect(Collectors.toList()));
+                });
+            }
+
+            return async.eventuallyCollect(deletes, newDeleteCollector(), deleteParallelism);
+        }));
     }
 
     @Override
@@ -344,6 +376,43 @@ public class MetadataBackendKV extends AbstractElasticsearchMetadataBackend
 
             return scrollEntries(c, builder, limit, converter).directTransform(collector);
         });
+    }
+
+    /**
+     * Collect the result of a list of operations and convert into a
+     * {@link com.spotify.heroic.metadata.DeleteSeries}.
+     *
+     * @return a {@link eu.toolchain.async.StreamCollector}
+     */
+    private StreamCollector<Void, DeleteSeries> newDeleteCollector() {
+        return new StreamCollector<Void, DeleteSeries>() {
+            final ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+            @Override
+            public void resolved(final Void result) throws Exception {
+            }
+
+            @Override
+            public void failed(final Throwable cause) throws Exception {
+                errors.add(cause);
+            }
+
+            @Override
+            public void cancelled() throws Exception {
+            }
+
+            @Override
+            public DeleteSeries end(
+                final int resolved, final int failed, final int cancelled
+            ) throws Exception {
+                final List<RequestError> errors = this.errors
+                    .stream()
+                    .map(QueryError::fromThrowable)
+                    .collect(Collectors.toList());
+
+                return new DeleteSeries(errors, resolved, failed + cancelled);
+            }
+        };
     }
 
     private <T, O> AsyncObservable<O> entriesStream(

--- a/metadata/elasticsearch/src/test/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendV1IT.java
+++ b/metadata/elasticsearch/src/test/java/com/spotify/heroic/metadata/elasticsearch/MetadataBackendV1IT.java
@@ -35,6 +35,9 @@ public class MetadataBackendV1IT extends AbstractElasticsearchMetadataBackendIT 
     protected void setupConditions() {
         super.setupConditions();
 
+        // TODO: deprecate V1 completely instead of fixing this?
+        deleteSupport = false;
+
         // TODO: find out and fix the issue
         orFilterSupport = false;
     }


### PR DESCRIPTION
This adds delete support to your excellent branch for kv-typed backends to allow all tests to pass.

I've not added it to V1 since it is being deprecated, to allow the test to pass I've added the `deleteSupport` flag to the integration tests which can be set by test classes (see `MetadataBackendV1IT`).

The overall support is built by taking the result from findSeriesIds, and deleting each returned document in batches. The batch implementation uses `eventuallyCollect(...)` to control how many deletes are running in parallel for a single request.
